### PR TITLE
fix: Add postcss.config.js to enable Tailwind CSS

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}


### PR DESCRIPTION
- Creates a `postcss.config.js` file with standard settings for `tailwindcss` and `autoprefixer`.
- This explicit configuration is necessary to resolve an issue where Tailwind styles were not being processed and applied during the build, causing the application to render without CSS.