### PR TITLE
fix: Update CSP to allow inline styles

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -18,7 +18,7 @@
         "headers": [
           {
             "key": "Content-Security-Policy",
-            "value": "default-src 'self'; script-src 'self' 'unsafe-inline'"
+            "value": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'"
           },
           {
             "key": "X-Frame-Options",


### PR DESCRIPTION
This commit updates the Content Security Policy (CSP) in `firebase.json` to allow the use of inline styles.

The previous policy was blocking inline `style` attributes, which are used by libraries like Framer Motion for animations, causing rendering issues.

The `style-src 'self' 'unsafe-inline'` directive has been added to the CSP to resolve these errors.