### PR TITLE
feat: enable CV download from hero section

### DIFF
--- a/components/sections/HeroSection.tsx
+++ b/components/sections/HeroSection.tsx
@@ -32,7 +32,7 @@ const HeroSection = () => {
           </p>
           <div className="flex flex-col sm:flex-row gap-4 justify-center items-center">
             <Button asChild className="bg-blue-600 hover:bg-blue-700 text-white">
-              <Link href={personalInfo.cvUrl}>
+              <Link href={personalInfo.cvUrl} download="CV_DAVID_MENDEZ.pdf">
                 <icons.Download className="w-5 h-5 mr-2" />
                 Download CV
               </Link>

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -12,7 +12,7 @@ import {
     title: "Full-Stack & Cloud Solutions Architect",
     summary: "I turn complex problems into scalable, battle-tested software",
     logo: "DM",
-    cvUrl: "#", // TODO: Add CV URL
+    cvUrl: "https://tecnosalta.dev/CV_DAVID_MENDEZ.pdf",
   };
 
   export const socialLinks = [


### PR DESCRIPTION
Updates the hero section to allow users to download the CV.

- Modifies `lib/data.ts` to include the correct URL for the CV PDF.
- Adds the `download` attribute to the `Link` component in `HeroSection.tsx` to trigger the browser's download functionality upon clicking the 'Download CV' button.