### PR TITLE
fix: Point Firebase hosting to correct build directory

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,6 +1,6 @@
 {
   "hosting": {
-    "public": "public",
+    "public": "dist",
     "ignore": [
       "firebase.json",
       "**/.*",


### PR DESCRIPTION
This commit fixes a misconfiguration in `firebase.json` where the hosting `public` directory was pointing to the wrong folder (`public` instead of `dist`).

This misconfiguration caused requests for static assets (CSS, JS) to be served the `index.html` file, leading to strict MIME type errors and a broken site.

The `public` property in `firebase.json` has been updated to `dist`, which is the correct output directory for the Next.js static export.